### PR TITLE
Enforce per-tx limits on CDSV sigops

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -139,6 +139,12 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& in
     return nSigOps;
 }
 
+uint64_t GetTransactionSigOpCount(const CTransaction &tx,
+                                  const CCoinsViewCache &view, uint32_t flags) {
+    return GetLegacySigOpCount(tx, flags) +
+           GetP2SHSigOpCount(tx, view, flags);
+}
+
 bool CheckTransaction(const CTransaction& tx, CValidationState &state)
 {
     // Basic checks that don't depend on any context

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -48,6 +48,17 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx,
                                uint32_t scriptFlags);
 
 /**
+ * Compute total signature operation of a transaction.
+ * @param[in] tx     Transaction for which we are computing the cost
+ * @param[in] inputs Map of previous transactions that have outputs we're
+ * spending
+ * @param[in] flags  Script verification flags
+ * @return Total signature operation cost of tx
+ */
+uint64_t GetTransactionSigOpCount(const CTransaction &tx,
+                                  const CCoinsViewCache &inputs,
+                                  uint32_t flags);
+/**
  * Check if transaction is final and can be included in a block with the
  * specified height and time. Consensus critical.
  */

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -104,42 +104,6 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount) {
     CheckScriptSigOps(s5, 2, 20, 2);
 }
 
-BOOST_AUTO_TEST_CASE(test_max_sigops_per_tx) {
-    CMutableTransaction tx;
-    tx.nVersion = 1;
-    tx.vin.resize(1);
-    tx.vin[0].prevout.hash = GetRandHash();
-    tx.vin[0].prevout.n = 0;
-    tx.vin[0].scriptSig = CScript();
-    tx.vout.resize(1);
-    tx.vout[0].nValue = 1;
-    tx.vout[0].scriptPubKey = CScript();
-
-    {
-        CValidationState state;
-        BOOST_CHECK(CheckTransaction(tx, state));
-    }
-
-    // Get just before the limit.
-    for (size_t i = 0; i < MAX_TX_SIGOPS_COUNT; i++) {
-        tx.vout[0].scriptPubKey << OP_CHECKSIG;
-    }
-
-    {
-        CValidationState state;
-        BOOST_CHECK(CheckTransaction(tx, state));
-    }
-
-    // And go over.
-    tx.vout[0].scriptPubKey << OP_CHECKSIG;
-
-    {
-        CValidationState state;
-        BOOST_CHECK(!CheckTransaction(tx, state));
-        BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txn-sigops");
-    }
-}
-
 /**
  * Verifies script execution of the zeroth scriptPubKey of tx output and
  * zeroth scriptSig of tx input.
@@ -163,24 +127,29 @@ ScriptError VerifyWithFlag(const CTransaction& output, const CMutableTransaction
  */
 void BuildTxs(CMutableTransaction& spendingTx, CCoinsViewCache& coins,
               CMutableTransaction& creationTx, const CScript& scriptPubKey,
-              const CScript& scriptSig)
+              const CScript& scriptSig, const CScript& outScript, size_t count = 1)
 {
     creationTx.nVersion = 1;
-    creationTx.vin.resize(1);
-    creationTx.vin[0].prevout.SetNull();
-    creationTx.vin[0].scriptSig = CScript();
-    creationTx.vout.resize(1);
-    creationTx.vout[0].nValue = 1;
-    creationTx.vout[0].scriptPubKey = scriptPubKey;
+    creationTx.vin.resize(count);
+    creationTx.vout.resize(count);
+    for (size_t i = 0; i < count; i++) {
+        creationTx.vin[i].prevout.SetNull();
+        creationTx.vin[i].scriptSig = CScript();
+        creationTx.vout[i].nValue = 1;
+        creationTx.vout[i].scriptPubKey = scriptPubKey;
+    }
+    uint256 creationHash = creationTx.GetHash();
 
     spendingTx.nVersion = 1;
-    spendingTx.vin.resize(1);
-    spendingTx.vin[0].prevout.hash = creationTx.GetHash();
-    spendingTx.vin[0].prevout.n = 0;
-    spendingTx.vin[0].scriptSig = scriptSig;
-    spendingTx.vout.resize(1);
-    spendingTx.vout[0].nValue = 1;
-    spendingTx.vout[0].scriptPubKey = CScript();
+    spendingTx.vin.resize(count);
+    spendingTx.vout.resize(count);
+    for (size_t i = 0; i < count; i++) {
+        spendingTx.vin[i].prevout.hash = creationHash;
+        spendingTx.vin[i].prevout.n = i;
+        spendingTx.vin[i].scriptSig = scriptSig;
+        spendingTx.vout[i].nValue = 1;
+        spendingTx.vout[i].scriptPubKey = outScript;
+    }
 
     AddCoins(coins, CTransaction(creationTx), 0);
 }
@@ -209,16 +178,34 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         // Do not use a valid signature to avoid using wallet operations.
         CScript scriptSig = CScript() << OP_0 << OP_0;
 
-        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig);
-        // Legacy counting only includes signature operations in scriptSigs and scriptPubKeys
-        // of a transaction and does not take the actual executed sig operations into account.
-        // spendingTx in itself does not contain a signature operation.
-        BOOST_CHECK(GetLegacySigOpCount(CTransaction(spendingTx), flags) == 0);
-        // creationTx contains two signature operations in its scriptPubKey, but legacy counting
-        // is not accurate.
-        BOOST_CHECK(GetLegacySigOpCount(CTransaction(creationTx), flags) == MAX_PUBKEYS_PER_MULTISIG);
-        // Sanity check: script verification fails because of an invalid signature.
-        BOOST_CHECK(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_CHECKMULTISIGVERIFY);
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, CScript());
+
+        // Legacy counting only includes signature operations in scriptSigs and
+        // scriptPubKeys of a transaction and does not take the actual executed
+        // sig operations into account. spendingTx in itself does not contain a
+        // signature operation.
+        BOOST_CHECK_EQUAL(
+            GetTransactionSigOpCount(CTransaction(spendingTx), coins, flags),
+            0);
+        // creationTx contains two signature operations in its scriptPubKey, but
+        // legacy counting is not accurate.
+        BOOST_CHECK_EQUAL(
+            GetTransactionSigOpCount(CTransaction(creationTx), coins, flags),
+            MAX_PUBKEYS_PER_MULTISIG);
+        // Sanity check: script verification fails because of an invalid
+        // signature.
+        BOOST_CHECK_EQUAL(
+            VerifyWithFlag(CTransaction(creationTx), spendingTx, flags),
+            SCRIPT_ERR_CHECKMULTISIGVERIFY);
+
+        // Make sure non P2SH sigops are counted even if the flag for P2SH is
+        // not passed in.
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(CTransaction(spendingTx),
+                                                   coins, SCRIPT_VERIFY_NONE),
+                          0);
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(CTransaction(creationTx),
+                                                   coins, SCRIPT_VERIFY_NONE),
+                          MAX_PUBKEYS_PER_MULTISIG);
     }
 
     // Multisig nested in P2SH
@@ -227,14 +214,69 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         CScript scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
         CScript scriptSig = CScript() << OP_0 << OP_0 << ToByteVector(redeemScript);
 
-        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig);
-        BOOST_CHECK(GetP2SHSigOpCount(CTransaction(spendingTx), coins, flags) == 2);
-        BOOST_CHECK(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_CHECKMULTISIGVERIFY);
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, CScript());
+
+        BOOST_CHECK_EQUAL(
+            GetTransactionSigOpCount(CTransaction(spendingTx), coins, flags),
+            2);
+        BOOST_CHECK_EQUAL(
+            VerifyWithFlag(CTransaction(creationTx), spendingTx, flags),
+            SCRIPT_ERR_CHECKMULTISIGVERIFY);
 
         // Make sure P2SH sigops are not counted if the flag for P2SH is not
         // passed in.
-        BOOST_CHECK_EQUAL(GetP2SHSigOpCount(CTransaction(spendingTx),
-                    coins, SCRIPT_VERIFY_NONE), 0);
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(CTransaction(spendingTx),
+                                                   coins, SCRIPT_VERIFY_NONE),
+                          0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_max_sigops_per_tx) {
+    const uint32_t flags = SCRIPT_VERIFY_P2SH;
+
+    CMutableTransaction creationTx, spendingTx;
+    CCoinsView coinsDummy;
+    CCoinsViewCache coins(&coinsDummy);
+    CKey key;
+    key.MakeNewKey(true);
+    CPubKey pubkey = key.GetPubKey();
+
+    // Each vin/vout pair contributes 3 sigops
+    CScript redeemScript = CScript() << 1 << ToByteVector(pubkey) << ToByteVector(pubkey) << 2 << OP_CHECKMULTISIGVERIFY;
+    CScript scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
+    CScript scriptSig = CScript() << OP_0 << OP_0 << ToByteVector(redeemScript);
+    CScript outScript = CScript() << OP_CHECKSIG;
+
+    // Build spendingTx by starting with some P2SH inputs. Also exercise multiple outputs.
+    const size_t p2shInputCount = 20;
+    BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, outScript, p2shInputCount);
+
+    uint64_t sigopsCount = GetTransactionSigOpCount(spendingTx, coins, flags);
+    BOOST_CHECK_EQUAL(sigopsCount, p2shInputCount * 3);
+    {
+        CValidationState state;
+        BOOST_CHECK(CheckTransaction(spendingTx, state));
+    }
+
+    // Push the combined input+output count over the limit
+    for (size_t i = sigopsCount; i < MAX_TX_SIGOPS_COUNT + 1; i++) {
+        spendingTx.vout[0].scriptPubKey << OP_CHECKSIG;
+    }
+    sigopsCount = GetTransactionSigOpCount(spendingTx, coins, flags);
+    BOOST_CHECK_EQUAL(sigopsCount, MAX_TX_SIGOPS_COUNT + 1);
+    {
+        CValidationState state;
+        BOOST_CHECK(CheckTransaction(spendingTx, state)); // Not sensitive to the p2sh inputs
+    }
+
+    // Exceed the limit with outputs alone
+    for (size_t i = 0; i < p2shInputCount * 2; i++) {
+        spendingTx.vout[0].scriptPubKey << OP_CHECKSIG;
+    }
+    {
+        CValidationState state;
+        BOOST_CHECK(!CheckTransaction(spendingTx, state));
+        BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txn-sigops");
     }
 }
 


### PR DESCRIPTION
In AcceptToMemoryPool, set fork-dependent script verification flags prior to checking the transaction sigop limit. Otherwise the check will fail to count CDS/CDSV sigops as per BCH 2018-11 fork spec.

An improved test for the per-tx sigops maximum is included, and helper function GetTransactionSigOpCount is added for consistency with other implementations.

Atop #3.