### PR TITLE
[security] Improved DAA: Weighted-Time EMA

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -94,6 +94,7 @@ BITCOIN_TESTS =\
   test/p2p_protocol_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
+  test/pow_tests.cpp \
   test/processmessage_tests.cpp \
   test/raii_event_tests.cpp \
   test/ReceiveMsgBytes_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -88,8 +88,8 @@ public:
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowAlphaReciprocal = 110;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
 
@@ -115,6 +115,7 @@ public:
 
         // BIP100 max block size change critical vote position
         consensus.nMaxBlockSizeChangePosition = 1512;
+        consensus.nMaxBlockSizeAdjustmentInterval = 2016;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -174,8 +175,8 @@ public:
         strNetworkID = "test";
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowAlphaReciprocal = 110;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
 
@@ -201,6 +202,7 @@ public:
 
         // BIP100 max block size change critical vote position
         consensus.nMaxBlockSizeChangePosition = 1512;
+        consensus.nMaxBlockSizeAdjustmentInterval = 2016;
 
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
@@ -280,11 +282,12 @@ public:
         consensus.nSubsidyHalvingInterval = 150;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.fPowNoRetargeting = true;
-        consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowAlphaReciprocal = 110;
         consensus.fPowAllowMinDifficultyBlocks = true;
 
         consensus.nMaxBlockSizeChangePosition = 1512;
+        consensus.nMaxBlockSizeAdjustmentInterval = 2016;
 
         // BIP135 functional tests rely on deterministic block times
         int64_t MOCKTIME = 1388534400 + (201 * 10 * 60); // Jan 1, 2014

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -50,19 +50,22 @@ struct Params {
     int nSubsidyHalvingInterval;
     /** Defined BIP135 deployments. */
     std::map<DeploymentPos, ForkDeployment> vDeployments;
+
     /**
      * BIP100: One-based position from beginning (end) of the ascending sorted list of max block size
      * votes in a 2016-block interval, at which the possible new lower (higher) max block size is read.
      * 1512 = 75th percentile of 2016
      */
     uint32_t nMaxBlockSizeChangePosition;
+    uint32_t nMaxBlockSizeAdjustmentInterval;
+
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
-    int64_t nPowTargetTimespan;
-    int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
+    uint32_t nPowAlphaReciprocal;
+    int64_t DifficultyAdjustmentSpace() const { return nPowTargetSpacing * nPowAlphaReciprocal; }
 };
 } // namespace Consensus
 

--- a/src/maxblocksize.cpp
+++ b/src/maxblocksize.cpp
@@ -23,13 +23,13 @@ uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Par
     uint64_t nMaxBlockSize = pindexLast->nMaxBlockSize;
 
     // Only change once per difficulty adjustment interval
-    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0) {
+    if ((pindexLast->nHeight+1) % params.nMaxBlockSizeAdjustmentInterval != 0) {
         return nMaxBlockSize;
     }
 
     std::vector<uint64_t> votes;
     const CBlockIndex *pindexWalk = pindexLast;
-    for (int64_t i = 0; i < params.DifficultyAdjustmentInterval(); i++) {
+    for (int64_t i = 0; i < params.nMaxBlockSizeAdjustmentInterval; i++) {
         assert(pindexWalk);
         votes.push_back(pindexWalk->nMaxBlockSizeVote ? pindexWalk->nMaxBlockSizeVote : nMaxBlockSize);
         pindexWalk = pindexWalk->pprev;
@@ -37,7 +37,7 @@ uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Par
 
     std::sort(votes.begin(),votes.end());
     uint64_t lowerValue = votes.at(params.nMaxBlockSizeChangePosition - 1);
-    uint64_t raiseValue = votes.at(params.DifficultyAdjustmentInterval() - params.nMaxBlockSizeChangePosition);
+    uint64_t raiseValue = votes.at(params.nMaxBlockSizeAdjustmentInterval - params.nMaxBlockSizeChangePosition);
 
     assert(lowerValue >= 1000000); // minimal vote supported is 1MB
     assert(lowerValue >= raiseValue); // lowerValue comes from a higher sorted position

--- a/src/pow.h
+++ b/src/pow.h
@@ -15,7 +15,6 @@ class uint256;
 class arith_uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, uint32_t nextblocktime, const Consensus::Params&);
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -33,8 +33,7 @@
 using namespace std;
 
 /**
- * Return average network hashes per second based on the last 'lookup' blocks,
- * or from the last difficulty change if 'lookup' is nonpositive.
+ * Return average network hashes per second based on the last 'lookup' blocks.
  * If 'height' is nonnegative, compute the estimate at the time when a given block was found.
  */
 UniValue GetNetworkHashPS(int lookup, int height) {
@@ -46,9 +45,9 @@ UniValue GetNetworkHashPS(int lookup, int height) {
     if (pb == NULL || !pb->nHeight)
         return 0;
 
-    // If lookup is -1, then use blocks since last difficulty change.
+    // If lookup is non-positive then use 1
     if (lookup <= 0)
-        lookup = pb->nHeight % Params().GetConsensus().DifficultyAdjustmentInterval() + 1;
+        lookup = 1;
 
     // If lookup is larger than chain, then set it to chain length.
     if (lookup > pb->nHeight)

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(get_next_max_blocksize) {
     // Genesis block, legacy block size
     BOOST_CHECK_EQUAL(MAX_BLOCK_SIZE, GetNextMaxBlockSize(nullptr, params));
 
-    const int64_t interval = params.DifficultyAdjustmentInterval();
+    const int64_t interval = params.nMaxBlockSizeAdjustmentInterval;
 
     // Not at a difficulty adjustment interval,
     // should not change max block size.


### PR DESCRIPTION
To achieve faster response to hashrate changes, and to eliminate 144-block resonance, an improved difficulty adjustment algorithm is introduced.

Weighted-Time EMA weights the target implied by the latest observed blocktime by a fixed factor "alpha" and combines it with the previous target, which is reduced by the factor (1-alpha).

next = alpha * latest + (1-alpha) * previous

The change is constrained to the geometric interval [/1.1, *1.1].

Alpha is set to 1/110 so the half-life of a single block's effect is close to that of an unweighted 144-block average, and convenience in applying the change constraint.