### PR TITLE
Update CDSV deployment

### DIFF
--- a/qa/rpc-tests/bip135-checkdatasig-activation.py
+++ b/qa/rpc-tests/bip135-checkdatasig-activation.py
@@ -113,7 +113,7 @@ class CheckDataSigActivationTest(ComparisonTestFramework):
         tx0_hex = ToHex(tx0)
         assert_raises_rpc_error(-26, RPC_BAD_OPCODE_ERROR,
                                 node.sendrawtransaction, tx0_hex)
-        assert_equal(get_bip135_status(node, 'bip135test4')['status'], 'defined')
+        assert_equal(get_bip135_status(node, 'bip135test0')['status'], 'defined')
 
         # CDSV regtest start happens after height 299, activation should be at height 399
         self.log.info("Advance to height 398, just before activation, and check again")
@@ -138,7 +138,7 @@ class CheckDataSigActivationTest(ComparisonTestFramework):
             # create the block
             coinbase = create_coinbase(absoluteHeight=height+1)
             coinbase.rehash()
-            version = 0x20000010 # Signal for CDSV on bit 4
+            version = 0x20000001 # Signal for CDSV on bit 0
             block = create_block(int(node.getbestblockhash(), 16), coinbase,
                                  int(blockchaininfo['mediantime']) + 1, nVersion=version)
 
@@ -158,14 +158,14 @@ class CheckDataSigActivationTest(ComparisonTestFramework):
         add_tx(b, tx0)
         yield rejected(b, RejectResult(16, b'blk-bad-inputs')) #1
 
-        assert_equal(get_bip135_status(node, 'bip135test4')['status'], 'locked_in')
+        assert_equal(get_bip135_status(node, 'bip135test0')['status'], 'locked_in')
 
 
         self.log.info("Activates checkdatasig")
         fork_block = next_block()
         yield accepted(fork_block) #2
 
-        assert_equal(get_bip135_status(node, 'bip135test4')['status'], 'active')
+        assert_equal(get_bip135_status(node, 'bip135test0')['status'], 'active')
 
         tx0id = node.sendrawtransaction(tx0_hex)
         assert(tx0id in set(node.getrawmempool()))

--- a/qa/rpc-tests/bip135-threshold.py
+++ b/qa/rpc-tests/bip135-threshold.py
@@ -183,7 +183,7 @@ class BIP135ForksTest(ComparisonTestFramework):
         # 95 blocks total for bit 5
         test_blocks = self.generate_blocks(20, 0x200000E1)
         yield TestInstance(test_blocks, sync_every_block=False)
-        assert_equal(get_bip135_status(node, self.defined_forks[4])['status'], 'started')
+        assert_equal(get_bip135_status(node, self.defined_forks[4])['status'], 'locked_in')
 
         # 99 blocks total for bit 6
         test_blocks = self.generate_blocks(4, 0x200000C1)
@@ -196,8 +196,12 @@ class BIP135ForksTest(ComparisonTestFramework):
         assert(self.height % 100 == 99)
 
         bcinfo = node.getblockchaininfo()
+        assert_equal(bcinfo['bip135_forks'][f]['status'], 'locked_in')
         for f in self.defined_forks[2:]:
-            assert_equal(bcinfo['bip135_forks'][f]['status'], 'locked_in')
+            if int(f[10:]) == 4:
+                assert_equal(bcinfo['bip135_forks'][f]['status'], 'active')
+            else:
+                assert_equal(bcinfo['bip135_forks'][f]['status'], 'locked_in')
         assert_equal(bcinfo['bip135_forks'][self.defined_forks[1]]['status'], 'started')
 
         # move to start of new 144-block window
@@ -218,7 +222,6 @@ class BIP135ForksTest(ComparisonTestFramework):
         '''
         run various tests
         '''
-        # CSV (bit 0) for backward compatibility with BIP9
         for test in itertools.chain(
                 self.test_BIP135Thresholds(),  # test thresholds on other bits
         ):

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -96,12 +96,12 @@ public:
         // CHECKDATASIGVERIFY
         consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].name = "cdsv";
         consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].gbt_force = true;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].nStartTime = 1557921600LL; // Wednesday, May 15, 2019 12:00:00 UTC
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].nTimeout = 1589457600LL; // Thursday, May 14, 2020 12:00:00 UTC
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].windowsize = 12960;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].nStartTime = 1571140800LL; // 2019-10-15T12:00:00+00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].nTimeout = 1602676800LL; // 2020-10-14T12:00:00+00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].windowsize = 12960; // ~ 90 days
         consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].threshold = 9720; // 75% of 12960
         consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].minlockedblocks = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].minlockedtime = 7776000; // 90 days
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].minlockedtime = 0;
 
         // testing bit
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].name = "testdummy";
@@ -182,12 +182,12 @@ public:
         // CHECKDATASIGVERIFY
         consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].name = "cdsv";
         consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].gbt_force = true;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].nStartTime = 1555329600LL; // Monday, April 15, 2019 12:00:00 UTC
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].nTimeout = 1589457600LL; // Thursday, May 14, 2020 12:00:00 UTC
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].windowsize = 12960;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].threshold = 9720; // 75% of 12960
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].nStartTime = 1567339200LL; // 2019-09-01T12:00:00+00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].nTimeout = 1598875200LL; // 2020-08-31T12:00:00+00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].windowsize = 4320; // ~ 30 days
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].threshold = 3240; // 75% of 4320
         consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].minlockedblocks = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].minlockedtime = 7776000; // 90 days
+        consensus.vDeployments[Consensus::DEPLOYMENT_CDSV].minlockedtime = 0;
 
         // testing bit
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].name = "testdummy";
@@ -292,10 +292,10 @@ public:
         Consensus::DeploymentPos bip135test0 = static_cast<Consensus::DeploymentPos>(0);
         consensus.vDeployments[bip135test0].name = "bip135test0";
         consensus.vDeployments[bip135test0].gbt_force = true;
-        consensus.vDeployments[bip135test0].nStartTime = 0;
+        consensus.vDeployments[bip135test0].nStartTime = MOCKTIME + 30;
         consensus.vDeployments[bip135test0].nTimeout = 999999999999LL;
-        consensus.vDeployments[bip135test0].windowsize = 144;
-        consensus.vDeployments[bip135test0].threshold = 108;
+        consensus.vDeployments[bip135test0].windowsize = 100;
+        consensus.vDeployments[bip135test0].threshold = 75;
         consensus.vDeployments[bip135test0].minlockedblocks = 0;
         consensus.vDeployments[bip135test0].minlockedtime = 0;
 
@@ -335,7 +335,7 @@ public:
         consensus.vDeployments[bip135test4].nStartTime = MOCKTIME + 30;
         consensus.vDeployments[bip135test4].nTimeout = 999999999999LL;
         consensus.vDeployments[bip135test4].windowsize = 100;
-        consensus.vDeployments[bip135test4].threshold = 75;
+        consensus.vDeployments[bip135test4].threshold = 0;
         consensus.vDeployments[bip135test4].minlockedblocks = 0;
         consensus.vDeployments[bip135test4].minlockedtime = 0;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -14,7 +14,7 @@ namespace Consensus {
 
 enum DeploymentPos
 {
-    DEPLOYMENT_CDSV = 4, // CHECKDATASIG
+    DEPLOYMENT_CDSV = 0, // CHECKDATASIG
     DEPLOYMENT_TESTDUMMY = 28,
     MAX_VERSION_BITS_DEPLOYMENTS = 29
 };


### PR DESCRIPTION
Switch to bit 0.
Update start/timeout.
Use default locked_in period rather than an extended period.

Use the open bit 4 on regtest to test a deployment with 0 threshold.