### PR TITLE
QT: blockchain size at startup

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -18,7 +18,7 @@
 
 /* Minimum free space (in bytes) needed for data directory */
 static const uint64_t GB_BYTES = 1000000000LL;
-static const uint64_t BLOCK_CHAIN_SIZE = 200LL * GB_BYTES;
+static const uint64_t BLOCK_CHAIN_SIZE = 1LL * GB_BYTES;
 
 /* Check free space asynchronously to prevent hanging the UI thread.
 


### PR DESCRIPTION
It shows 200GB at startup. But its size is much smaller than this. I fixed the size as 1GB.